### PR TITLE
:arrow_up: Upgrade to libhal-util/5.0.0

### DIFF
--- a/.github/workflows/4.0.0.yml
+++ b/.github/workflows/4.0.0.yml
@@ -1,0 +1,16 @@
+name: 🚀 Deploy 4.0.0
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: libhal/ci/.github/workflows/deploy.yml@5.x.y
+    with:
+      compiler: gcc
+      version: 4.0.0
+      arch: x86_64
+      compiler_version: 12.3
+      compiler_package: ""
+      os: Linux
+    secrets: inherit

--- a/conanfile.py
+++ b/conanfile.py
@@ -54,11 +54,11 @@ class libhal_mock_conan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("cmake/3.27.1")
-        self.tool_requires("libhal-cmake-util/3.0.1")
+        self.tool_requires("libhal-cmake-util/[^4.1.0]")
         self.test_requires("boost-ext-ut/1.1.9")
 
     def requirements(self):
-        self.requires("libhal-util/[^4.0.0]", transitive_headers=True)
+        self.requires("libhal-util/[^5.0.0]", transitive_headers=True)
 
     def layout(self):
         cmake_layout(self)

--- a/include/libhal-mock/adc.hpp
+++ b/include/libhal-mock/adc.hpp
@@ -36,10 +36,16 @@ struct adc : public hal::adc
   }
 
 private:
+  /**
+   * @brief mock implementation of driver_read()
+   *
+   * @return float - adc value from queue
+   * @throws throw hal::operation_not_permitted - if the adc queue runs out
+   */
   float driver_read() override
   {
     if (m_adc_values.size() == 0) {
-      throw std::out_of_range("adc floats queue is empty!");
+      throw hal::operation_not_permitted(this);
     }
     auto m_current_value = m_adc_values.front();
     m_adc_values.pop();

--- a/include/libhal-mock/input_pin.hpp
+++ b/include/libhal-mock/input_pin.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
+#include <libhal/error.hpp>
 #include <queue>
-#include <stdexcept>
 
 #include <libhal/input_pin.hpp>
 
@@ -55,12 +55,20 @@ private:
   {
     spy_configure.record(p_settings);
   }
+  /**
+   * @brief Mock implementation of input_pin::driver_level
+   *
+   * @return true - high voltage
+   * @return false - low voltage
+   * @throws throw hal::operation_not_permitted - if the input pin value queue
+   * runs out of elements
+   */
   bool driver_level() override
   {
     // This comparison performs bounds checking because front() and pop() do
     // not bounds check and results in undefined behavior if the queue is empty.
     if (m_levels.size() == 0) {
-      throw std::out_of_range("input_pin level queue is empty!");
+      throw hal::operation_not_permitted(this);
     }
     auto m_current_value = m_levels.front();
     m_levels.pop();

--- a/tests/can.test.cpp
+++ b/tests/can.test.cpp
@@ -75,8 +75,8 @@ void can_mock_test()
     expect(that % expected2.id ==
            std::get<0>(mock.spy_send.call_history().at(1)).id);
 
-    [[maybe_unused]] auto f =
-      throws<hal::operation_not_supported>([&]() { mock.send(expected2); });
+    expect(
+      throws<hal::operation_not_supported>([&]() { mock.send(expected2); }));
     expect(that % expected2.payload ==
            std::get<0>(mock.spy_send.call_history().at(2)).payload);
     expect(that % expected2.id ==
@@ -107,8 +107,8 @@ void can_mock_test()
     handler2(expected_message);
     expect(that % 0 == counter);
 
-    [[maybe_unused]] auto t = throws<hal::operation_not_supported>(
-      [&]() { mock.on_receive(expected2); });
+    expect(throws<hal::operation_not_supported>(
+      [&]() { mock.on_receive(expected2); }));
     auto handler3 = std::get<0>(mock.spy_on_receive.call_history().at(2));
     handler3(expected_message);
     expect(that % -1 == counter);

--- a/tests/input_pin.test.cpp
+++ b/tests/input_pin.test.cpp
@@ -19,6 +19,7 @@
 #include <libhal-mock/input_pin.hpp>
 
 #include <boost/ut.hpp>
+#include <libhal/error.hpp>
 
 namespace hal::mock {
 void input_pin_mock_test()
@@ -60,8 +61,8 @@ void input_pin_mock_test()
     expect(that % true == mock.level());
     expect(that % false == mock.level());
     expect(that % true == mock.level());
-    [[maybe_unused]] auto f =
-      throws([&]() { [[maybe_unused]] auto level = mock.level(); });
+    expect(throws<hal::operation_not_permitted>(
+      [&]() { [[maybe_unused]] auto level = mock.level(); }));
   };
   "hal::mock::input_pin::reset()"_test = []() {
     // Setup

--- a/tests/testing.test.cpp
+++ b/tests/testing.test.cpp
@@ -14,7 +14,7 @@
 
 #include <libhal-mock/pwm.hpp>
 
-#include <exception>
+#include <libhal/error.hpp>
 
 #include <boost/ut.hpp>
 
@@ -27,11 +27,10 @@ void testing_utilities_test()
 
   expect(that % 0 == spy.call_history().size());
 
-  spy.trigger_error_on_call(4,
-                            [&]() { throw std::out_of_range("out of range"); });
+  spy.trigger_error_on_call(
+    4, [&]() { throw hal::operation_not_permitted(&spy); });
 
-  [[maybe_unused]] auto a =
-    throws<std::out_of_range>([&]() { spy.record(1, 'A'); });
+  spy.record(1, 'A');
 
   expect(that % 1 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
@@ -39,8 +38,7 @@ void testing_utilities_test()
   expect(that % 'A' == std::get<1>(spy.call_history().at(0)));
   expect(that % 'A' == spy.history<1>(0));
 
-  [[maybe_unused]] auto b =
-    throws<std::out_of_range>([&]() { spy.record(2, 'B'); });
+  spy.record(2, 'B');
 
   expect(that % 2 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
@@ -52,8 +50,7 @@ void testing_utilities_test()
   expect(that % 'B' == std::get<1>(spy.call_history().at(1)));
   expect(that % 'B' == spy.history<1>(1));
 
-  [[maybe_unused]] auto c =
-    throws<std::out_of_range>([&]() { spy.record(3, 'C'); });
+  spy.record(3, 'C');
 
   expect(that % 3 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
@@ -69,8 +66,7 @@ void testing_utilities_test()
   expect(that % 'C' == std::get<1>(spy.call_history().at(2)));
   expect(that % 'C' == spy.history<1>(2));
 
-  [[maybe_unused]] auto d =
-    throws<std::out_of_range>([&]() { spy.record(4, 'D'); });
+  expect(throws<hal::operation_not_permitted>([&]() { spy.record(4, 'D'); }));
 
   expect(that % 4 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
@@ -94,8 +90,7 @@ void testing_utilities_test()
 
   expect(that % 0 == spy.call_history().size());
 
-  [[maybe_unused]] auto e =
-    throws<std::out_of_range>([&]() { spy.record(1, 'A'); });
+  spy.record(1, 'A');
 
   expect(that % 1 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
@@ -103,8 +98,7 @@ void testing_utilities_test()
   expect(that % 'A' == std::get<1>(spy.call_history().at(0)));
   expect(that % 'A' == spy.history<1>(0));
 
-  [[maybe_unused]] auto f =
-    throws<std::out_of_range>([&]() { spy.record(2, 'B'); });
+  spy.record(2, 'B');
 
   expect(that % 2 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
@@ -116,8 +110,7 @@ void testing_utilities_test()
   expect(that % 'B' == std::get<1>(spy.call_history().at(1)));
   expect(that % 'B' == spy.history<1>(1));
 
-  [[maybe_unused]] auto g =
-    throws<std::out_of_range>([&]() { spy.record(3, 'C'); });
+  spy.record(3, 'C');
 
   expect(that % 3 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
@@ -133,8 +126,8 @@ void testing_utilities_test()
   expect(that % 'C' == std::get<1>(spy.call_history().at(2)));
   expect(that % 'C' == spy.history<1>(2));
 
-  [[maybe_unused]] auto h =
-    throws<std::out_of_range>([&]() { spy.record(4, 'D'); });
+  // With reset, the error recording count is also turned off
+  spy.record(4, 'D');
 
   expect(that % 4 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));


### PR DESCRIPTION
Encountered a bug with std::logic_error see this action:

- https://github.com/libhal/libhal-mock/actions/runs/9056880780/job/24880028469?pr=11

And see this github issue:

- https://github.com/microsoft/DirectXShaderCompiler/issues/5971

Rather than remove this check using the suggested:
"ASAN_OPTIONS=alloc_dealloc_mismatch="0", we can simply stop using
std::exception derived types and just make/use our own for testing
purposes.